### PR TITLE
Change name Surfnet to SURFconext

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ build:
     - set -euxo pipefail
     - ./build.sh
     - mkdir build
-    - cp -R ./{css,edugain,js,linkedin,surfnet,twitter,vendor} build
+    - cp -R ./{css,edugain,js,linkedin,surfconext,twitter,vendor} build
     - cp *.php build
     - rm build/*.sample.php
   artifacts:

--- a/edugain/index.php
+++ b/edugain/index.php
@@ -2,7 +2,7 @@
 
 require_once '../config.php';
 
-define('PROVIDER',  'surfnet');
+define('PROVIDER', 'surfnet');
 define('PROVIDER_NAME', 'eduGAIN');
 define('CREDENTIAL', IRMA_ISSUER_ID . '.surfnet-2');
 define('IRMA_NAME_ATTRIBUTE', 'fullname');

--- a/edugain/index.php
+++ b/edugain/index.php
@@ -4,7 +4,6 @@ require_once '../config.php';
 
 define('PROVIDER',  'surfnet');
 define('PROVIDER_NAME', 'eduGAIN');
-define('SERVER_NAME', 'surfnet_enroll');
 define('CREDENTIAL', IRMA_ISSUER_ID . '.surfnet-2');
 define('IRMA_NAME_ATTRIBUTE', 'fullname');
 define('VALIDITY', '+3 months');

--- a/index.php
+++ b/index.php
@@ -3,10 +3,10 @@
 require_once 'config.php';
 
 if (!defined('PROVIDER')) {
-    // Trying to load this PHP script directly (old style), redirect to surfnet
+    // Trying to load this PHP script directly (old style), redirect to surfconext
     // issuer.
-    header('Location: surfnet/', true, 301);
-    exit('redirect to surfnet/');
+    header('Location: surfconext/', true, 301);
+    exit('redirect to surfconext/');
 }
 
 use \Firebase\JWT\JWT;

--- a/linkedin/index.php
+++ b/linkedin/index.php
@@ -4,7 +4,6 @@ require_once '../config.php';
 
 define('PROVIDER', 'linkedin');
 define('PROVIDER_NAME', 'LinkedIn');
-define('SERVER_NAME', 'linkedin_enroll');
 define('CREDENTIAL', IRMA_ISSUER_ID . '.linkedin');
 define('IRMA_NAME_ATTRIBUTE', 'familyname');
 define('VALIDITY', '+1 year');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/privacybydesign/saml_issuer",
   "license": "MIT",
   "dependencies": {
-    "jquery": "^3.4.1",
-    "@privacybydesign/irmajs": "^0.1.7"
+    "@privacybydesign/irmajs": "^0.2.2",
+    "jquery": "^3.4.1"
   }
 }

--- a/surfconext/index.php
+++ b/surfconext/index.php
@@ -2,8 +2,8 @@
 
 require_once '../config.php';
 
-define('PROVIDER',  'surfnet');
-define('PROVIDER_NAME', 'Surfnet');
+define('PROVIDER', 'surfnet');
+define('PROVIDER_NAME', 'SURFconext');
 define('CREDENTIAL', IRMA_ISSUER_ID . '.surfnet-2');
 define('IRMA_NAME_ATTRIBUTE', 'fullname');
 define('VALIDITY', '+3 months');

--- a/surfnet/index.php
+++ b/surfnet/index.php
@@ -4,7 +4,6 @@ require_once '../config.php';
 
 define('PROVIDER',  'surfnet');
 define('PROVIDER_NAME', 'Surfnet');
-define('SERVER_NAME', 'surfnet_enroll');
 define('CREDENTIAL', IRMA_ISSUER_ID . '.surfnet-2');
 define('IRMA_NAME_ATTRIBUTE', 'fullname');
 define('VALIDITY', '+3 months');

--- a/twitter/index.php
+++ b/twitter/index.php
@@ -4,7 +4,6 @@ require_once '../config.php';
 
 define('PROVIDER', 'twitter');
 define('PROVIDER_NAME', 'Twitter');
-define('SERVER_NAME', 'twitter_enroll');
 define('CREDENTIAL', IRMA_ISSUER_ID . '.twitter');
 define('IRMA_NAME_ATTRIBUTE', 'fullname');
 define('PROFILE_URL_FORMAT', 'https://twitter.com/:username:');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,18 +2,45 @@
 # yarn lockfile v1
 
 
-"@privacybydesign/irmajs@^0.1.7":
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/@privacybydesign/irmajs/-/irmajs-0.1.7.tgz#7942d7dc95b95b326ba0449c84986561177b4231"
-  integrity sha512-ZRdh0GjNIWLTxTh8w/DvuoqUdbY6SZMi1KXNWMJIMvk9pZDpH8kg+hysvJ47xsbS4ThKFRVTYQeC/+/eT6dkBA==
+"@privacybydesign/irma-client@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@privacybydesign/irma-client/-/irma-client-0.3.3.tgz#8b78b8eda517e1d8bcb01ce86cb0698770c9d09e"
+  integrity sha512-wn6N5TDj9M/KS9xfU2SA9GQM7rQaByFy84xj/lW4Ml6dR8oOObi/EdBKOqwb7Y2icUl+G+y0Tl1sx1fHUg9dBQ==
   dependencies:
-    es6-object-assign "^1.1.0"
-    es6-promise "^4.2.5"
+    deepmerge "^4.2.2"
     eventsource "^1.0.7"
-    isomorphic-fetch "^2.2.1"
-    jsonwebtoken "^8.4.0"
-    qrcode "^1.3.0"
+    isomorphic-fetch "^3.0.0"
+
+"@privacybydesign/irma-console@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@privacybydesign/irma-console/-/irma-console-0.3.3.tgz#3eabf813474aee3612550fcbc4e31721d306dfa2"
+  integrity sha512-BZ13R5Ech77BH1SzYsJPT5L4AWl89WVBpCqcJLra0dSmB5C4wDiVyt4AH88D5nGJlejQ/u3mKUsGGRoN5inl6A==
+  dependencies:
+    prompt-sync "^4.1.7"
     qrcode-terminal "^0.12.0"
+
+"@privacybydesign/irma-core@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@privacybydesign/irma-core/-/irma-core-0.3.3.tgz#6a010a5702aebdc644fa48da79e1e019917072bc"
+  integrity sha512-qhhOZeeAhC1eME+ZYr8d9lokSLY0Nejhuou7dTvz0y0HIocJyIzzmz/sD6rnXaRAQ7QRYd5C73l7mT88D1X0XQ==
+
+"@privacybydesign/irma-jwt@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@privacybydesign/irma-jwt/-/irma-jwt-0.1.1.tgz#29e949ec7604e1572f2a65546bb17b31a75f1100"
+  integrity sha512-A2aQI/mVv5frhbfDxKzhM71tqwLEJKab5NuwfOp/EGeWYTlSrujC7YkWT57nbBe20U0JCbE9MmqmcFyYZuyWAA==
+  dependencies:
+    jsonwebtoken "^8.5.1"
+
+"@privacybydesign/irmajs@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@privacybydesign/irmajs/-/irmajs-0.2.2.tgz#7d2b28ef12817f46bb34707eb2e2c02d2d984417"
+  integrity sha512-EzZ2IBhQwIklVSnnahraojQm/l4Z47NfstYM8Cl2gEbtJamxpWRxGdPQxucR2Loro2snGJ5t73RbQ1rY/mufbQ==
+  dependencies:
+    "@privacybydesign/irma-client" "^0.3.3"
+    "@privacybydesign/irma-console" "^0.3.3"
+    "@privacybydesign/irma-core" "^0.3.3"
+    "@privacybydesign/irma-jwt" "^0.1.1"
+    qrcode "^1.4.4"
 
 ansi-regex@^4.1.0:
   version "4.1.0"
@@ -27,10 +54,46 @@ ansi-styles@^3.2.0:
   dependencies:
     color-convert "^1.9.0"
 
+base64-js@^1.3.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
+  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
+
+buffer-alloc-unsafe@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
+  integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
+
+buffer-alloc@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
+  integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
+  dependencies:
+    buffer-alloc-unsafe "^1.1.0"
+    buffer-fill "^1.0.0"
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=
+
+buffer-fill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/buffer-fill/-/buffer-fill-1.0.0.tgz#f8f78b76789888ef39f205cd637f68e702122b2c"
+  integrity sha1-+PeLdniYiO858gXNY39o5wISKyw=
+
+buffer-from@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
+  integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+buffer@^5.4.3:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
+  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.1.13"
 
 camelcase@^5.0.0:
   version "5.3.1"
@@ -63,6 +126,11 @@ decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 dijkstrajs@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dijkstrajs/-/dijkstrajs-1.0.1.tgz#d3cd81221e3ea40742cfcde556d4e99e98ddc71b"
@@ -79,23 +147,6 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
-es6-object-assign@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/es6-object-assign/-/es6-object-assign-1.1.0.tgz#c2c3582656247c39ea107cb1e6652b6f9f24523c"
-  integrity sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=
-
-es6-promise@^4.2.5:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
 
 eventsource@^1.0.7:
   version "1.0.7"
@@ -116,42 +167,35 @@ get-caller-file@^2.0.1:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-iconv-lite@~0.4.13:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
+ieee754@^1.1.13:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
-is-stream@^1.0.1:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
-
 isarray@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
   integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
-isomorphic-fetch@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
   dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
 
 jquery@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
   integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
-jsonwebtoken@^8.4.0:
+jsonwebtoken@^8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
   integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
@@ -232,13 +276,10 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
+node-fetch@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 original@^1.0.0:
   version "1.0.2"
@@ -276,16 +317,26 @@ pngjs@^3.3.0:
   resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-3.4.0.tgz#99ca7d725965fb655814eaf65f38f12bbdbf555f"
   integrity sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==
 
+prompt-sync@^4.1.7:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/prompt-sync/-/prompt-sync-4.2.0.tgz#0198f73c5b70e3b03e4b9033a50540a7c9a1d7f4"
+  integrity sha512-BuEzzc5zptP5LsgV5MZETjDaKSWfchl5U9Luiu8SKp7iZWD5tZalOxvNcZRwv+d2phNFr8xlbxmFNcRKfJOzJw==
+  dependencies:
+    strip-ansi "^5.0.0"
+
 qrcode-terminal@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz#bb5b699ef7f9f0505092a3748be4464fe71b5819"
   integrity sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==
 
-qrcode@^1.3.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.4.2.tgz#e7c82a60140916d666541043bd2b0b72ee4e38a6"
-  integrity sha512-eR6RgxFYPDFH+zFLTJKtoNP/RlsHANQb52AUmQ2bGDPMuUw7jJb0F+DNEgx7qQGIElrbFxWYMc0/B91zLZPF9Q==
+qrcode@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.4.4.tgz#f0c43568a7e7510a55efc3b88d9602f71963ea83"
+  integrity sha512-oLzEC5+NKFou9P0bMj5+v6Z40evexeE29Z9cummZXZ9QXyMr3lphkURzxjXgPJC5azpxcshoDWV1xE46z+/c3Q==
   dependencies:
+    buffer "^5.4.3"
+    buffer-alloc "^1.2.0"
+    buffer-from "^1.1.1"
     dijkstrajs "^1.0.1"
     isarray "^2.0.1"
     pngjs "^3.3.0"
@@ -315,11 +366,6 @@ safe-buffer@^5.0.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
-
-"safer-buffer@>= 2.1.2 < 3":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 semver@^5.6.0:
   version "5.7.1"
@@ -355,10 +401,10 @@ url-parse@^1.4.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The PRs in `pbdf-website` `pbdf-schememanager` and the Ansible changes are also needed for this.

I kept the name of `surfnet` in the Provider, since a change here would need us to to contact SURF to update the SimpleSamlPHP return URLs. This makes migration more complex and those names are not visible to the user, so I kept the old name there.